### PR TITLE
CI update: Python 3.5 instead of 3.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ environment:
       MSYS2_DIR: msys64
       MSYSTEM: MINGW64
       BIT: 64
-      PYTHON_DIR: Python33-x64
+      PYTHON_DIR: Python35-x64
     - COMPILER: msys2
       PLATFORM: x64
       MSYS2_ARCH: x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   include:
     - os: linux
       language: python
-      python: "3.3"
+      python: "3.5"
       addons: &linux_addon
         apt:
           sources: ['ubuntu-toolchain-r-test']


### PR DESCRIPTION
Python 3.3 does not have `math.isclose`